### PR TITLE
Replace undefined constant E_NONE by 0 and remove error supression

### DIFF
--- a/source/joomlastart/defines.php
+++ b/source/joomlastart/defines.php
@@ -50,7 +50,7 @@ if(defined('KSDEBUG')) {
 	error_reporting(E_ALL | E_STRICT);
 	@ini_set('display_errors', 1);
 } else {
-	@error_reporting(E_NONE);
+	error_reporting(0);
 }
 
 // ==========================================================================================

--- a/source/kickstart/defines.php
+++ b/source/kickstart/defines.php
@@ -53,7 +53,7 @@ if(defined('KSDEBUG')) {
 	}
 	error_reporting(E_ALL | E_STRICT);
 } else {
-	@error_reporting(E_NONE);
+	error_reporting(0);
 }
 
 // ==========================================================================================

--- a/source/restore/postproc.ftp.php
+++ b/source/restore/postproc.ftp.php
@@ -412,7 +412,7 @@ class AKPostprocFTP extends AKAbstractPostproc
 	{
 		// Turn off error reporting
 		if(!defined('KSDEBUG')) {
-			$oldErrorReporting = @error_reporting(E_NONE);
+			$oldErrorReporting = error_reporting(0);
 		}
 
 		// Get UNIX style paths

--- a/source/restore/postproc.hybrid.php
+++ b/source/restore/postproc.hybrid.php
@@ -582,7 +582,7 @@ class AKPostprocHybrid extends AKAbstractPostproc
 		// Turn off error reporting
 		if (!defined('KSDEBUG'))
 		{
-			$oldErrorReporting = @error_reporting(E_NONE);
+			$oldErrorReporting = error_reporting(0);
 		}
 
 		// Get UNIX style paths

--- a/source/restore/postproc.sftp.php
+++ b/source/restore/postproc.sftp.php
@@ -430,7 +430,7 @@ class AKPostprocSFTP extends AKAbstractPostproc
 	{
 		// Turn off error reporting
 		if(!defined('KSDEBUG')) {
-			$oldErrorReporting = @error_reporting(E_NONE);
+			$oldErrorReporting = error_reporting(0);
 		}
 
 		// Get UNIX style paths


### PR DESCRIPTION
Because there is no such thing as `E_NONE`.
see PHP.net > Error Handling > [Predefined constants](http://php.net/manual/en/errorfunc.constants.php)